### PR TITLE
add : test for cli

### DIFF
--- a/__test__/CLI.spec.ts
+++ b/__test__/CLI.spec.ts
@@ -1,0 +1,16 @@
+// CLI.test.ts
+import { describe, expect, it } from "vitest";
+import { mockGenerateTasks } from "./CLIMock.ts";
+
+describe("CLI", () => {
+  it("should call generateTasks and buildEJS when --watch is not provided", async () => {
+    const mockInstance = mockGenerateTasks();
+
+    process.argv = ["node", "CLI.ts"];
+    await import("../src/CLI.ts");
+
+    expect(mockInstance.generateTasks).toHaveBeenCalled();
+    expect(mockInstance.mockWatchEJS).not.toHaveBeenCalled();
+    expect(mockInstance.mockBuildEJS).toHaveBeenCalled();
+  });
+});

--- a/__test__/CLI.spec.ts
+++ b/__test__/CLI.spec.ts
@@ -1,4 +1,3 @@
-// CLI.test.ts
 import { describe, expect, it } from "vitest";
 import { mockGenerateTasks } from "./CLIMock.ts";
 

--- a/__test__/CLI.watch.spec.ts
+++ b/__test__/CLI.watch.spec.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+import { mockGenerateTasks } from "./CLIMock.ts";
+
+describe("CLI", () => {
+  it.concurrent(
+    "should call generateTasks and watchEJS when --watch is provided",
+    async () => {
+      const mockInstance = mockGenerateTasks();
+
+      process.argv = ["node", "CLI.ts", "--watch"];
+      await import("../src/CLI.ts");
+
+      expect(mockInstance.generateTasks).toHaveBeenCalled();
+      expect(mockInstance.mockWatchEJS).toHaveBeenCalled();
+      expect(mockInstance.mockBuildEJS).not.toHaveBeenCalled();
+    },
+  );
+});

--- a/__test__/CLIMock.ts
+++ b/__test__/CLIMock.ts
@@ -1,0 +1,18 @@
+import { vi } from "vitest";
+import * as index from "../src/index.js";
+
+export const mockGenerateTasks = () => {
+  const mockWatchEJS = vi.fn();
+  const mockBuildEJS = vi.fn();
+
+  vi.spyOn(index, "generateTasks").mockReturnValue({
+    watchEJS: mockWatchEJS,
+    buildEJS: mockBuildEJS,
+  });
+
+  return {
+    generateTasks: index.generateTasks,
+    mockWatchEJS,
+    mockBuildEJS,
+  };
+};


### PR DESCRIPTION
CLIの引数パースに対する単体テストを追加。

process.argvはテストプロセス内で共有される。そのため、引数ごとに別のプロセスとしてテストを行なっている。