### PR TITLE
Migrate npm publishing to Trusted Publisher

### DIFF
--- a/.github/workflows/npm_publish.yml
+++ b/.github/workflows/npm_publish.yml
@@ -5,6 +5,9 @@ on:
 jobs:
   npm-publish:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write  # Required for OIDC authentication
+      contents: read   # Required for repository access
     steps:
       - name: Checkout
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
@@ -14,10 +17,10 @@ jobs:
           node-version: "20"
           cache: "npm"
           registry-url: "https://registry.npmjs.org"
+      - name: Upgrade npm to latest
+        run: npm install -g npm@latest
       - run: npm ci
       - name: build binary
         run: npm run build
       - name: Publish package on NPM 📦
         run: npm publish --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}


### PR DESCRIPTION
## Summary

This PR migrates npm package publishing from token-based authentication to NPM Trusted Publisher with OIDC authentication for enhanced security.

## NPM Trusted Publisher Configuration Completed

✅ **Manual setup completed on npmjs.com**:
- NPM Trusted Publisher configured for GitHub Actions
- GitHub Owner: `MasatoMakino`
- Repository: `gulptask-ejs`  
- Workflow filename: `npm_publish.yml`
- Publishing access set to "Require two-factor authentication and disallow tokens"

## Changes Made

### GitHub Actions Workflow Updates
- ✅ Added OIDC permissions (`id-token: write`, `contents: read`)
- ✅ Added npm upgrade step for latest OIDC support
- ✅ Removed `NODE_AUTH_TOKEN` environment variable
- ✅ Maintained existing action versions for stability
- ✅ Deleted `NPM_PUBLISH_TOKEN` repository secret

### Security Improvements
- **Eliminate long-lived tokens**: No more static NPM tokens in secrets
- **OIDC authentication**: Dynamic, short-lived credentials
- **Provenance statements**: Cryptographic proof of package integrity
- **Two-factor authentication**: Required for all publishing
- **Supply chain security**: Enhanced package authenticity verification

## Testing Plan

1. Create a test release on GitHub
2. Verify workflow executes successfully with OIDC authentication
3. Confirm package publishes without token authentication
4. Validate provenance statements are generated

## Migration Status

- [x] Update GitHub Actions workflow with OIDC permissions
- [x] Add npm upgrade step for OIDC compatibility
- [x] Remove NPM token from workflow environment
- [x] Delete repository secret `NPM_PUBLISH_TOKEN`
- [x] Configure NPM Trusted Publisher on npmjs.com
- [x] Set publishing access to disallow tokens
- [ ] Test publishing with OIDC authentication (post-merge)

🤖 Generated with [Claude Code](https://claude.ai/code)