### PR TITLE
fix: adjust Dependabot auto-merge workflow permissions

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,15 +1,19 @@
 name: Dependabot auto-merge
-on: 
+on:
   pull_request:
+    types: [opened]
     branches:
       - main
-      
+
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
+  pull-requests: read
 
 jobs:
   dependabot:
+    permissions:
+      contents: write
+      pull-requests: write
     runs-on: ubuntu-latest
     if: github.event.pull_request.user.login == 'dependabot[bot]' && github.repository == 'MasatoMakino/gulptask-ejs'
     steps:


### PR DESCRIPTION
## Summary
- Moved permissions to job level for better security isolation
- Added `types: [opened]` trigger for proper PR handling
- Updated workflow-level permissions to read-only as recommended practice

## Changes
- Workflow-level permissions set to read-only (`contents: read`, `pull-requests: read`)
- Job-level permissions grant necessary write access only to the specific job
- Added explicit trigger for opened pull requests

## Security Benefits
- Follows principle of least privilege
- Reduces attack surface by limiting permissions scope
- Aligns with GitHub Actions security best practices

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Refined CI workflow to trigger only on newly opened pull requests, reducing unnecessary runs.
  * Adopted least-privilege defaults for workflow permissions to enhance security.
  * Added job-scoped write permissions to preserve required actions (e.g., posting PR comments) without broad access.
  * No functional changes to automation behavior; existing auto-merge logic remains the same.
  * Improves maintenance and security posture with minimal user-facing impact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->