### PR TITLE
chore: archive repository and bump version to 0.4.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # gulptask-ejs
 
+> **Note:** This repository has been archived and is no longer maintained.
+> The npm package `@masatomakino/gulptask-ejs` has been deprecated.
+> Use EJS directly via its own API and CLI.
+
 [![MIT License](http://img.shields.io/badge/license-MIT-blue.svg?style=flat)](LICENSE)
 [![npm version](https://badge.fury.io/js/@masatomakino%2Fgulptask-ejs.svg)](https://badge.fury.io/js/@masatomakino%2Fgulptask-ejs)
-[![Test Coverage](https://api.codeclimate.com/v1/badges/ceeb454b472ad8a5b0a9/test_coverage)](https://codeclimate.com/github/MasatoMakino/gulptask-ejs/test_coverage)
-[![Maintainability](https://api.codeclimate.com/v1/badges/ceeb454b472ad8a5b0a9/maintainability)](https://codeclimate.com/github/MasatoMakino/gulptask-ejs/maintainability)

--- a/README.md
+++ b/README.md
@@ -1,8 +1,12 @@
 # gulptask-ejs
 
-> **Note:** This repository has been archived and is no longer maintained.
-> The npm package `@masatomakino/gulptask-ejs` has been deprecated.
-> Use EJS directly via its own API and CLI.
+> [!CAUTION]
+>
+> **This repository has been archived.**
+>
+> This package is deprecated. Use EJS directly via its own API and CLI.
+>
+> See [#310](https://github.com/MasatoMakino/gulptask-ejs/issues/310) for details.
 
 [![MIT License](http://img.shields.io/badge/license-MIT-blue.svg?style=flat)](LICENSE)
 [![npm version](https://badge.fury.io/js/@masatomakino%2Fgulptask-ejs.svg)](https://badge.fury.io/js/@masatomakino%2Fgulptask-ejs)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@masatomakino/gulptask-ejs",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@masatomakino/gulptask-ejs",
-      "version": "0.4.2",
+      "version": "0.4.3",
       "license": "MIT",
       "dependencies": {
         "chokidar": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@masatomakino/gulptask-ejs",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "description": "ejs compiler task for gulp.js",
   "type": "module",
   "exports": {


### PR DESCRIPTION
## Summary

Closes #310

Archive this repository and prepare the final release (v0.4.3).

**Changes:**
- Add archive/deprecation notice to README
- Remove stale CodeClimate badges
- Bump version to 0.4.3

**Unchanged:**
- All source code, workflows, and Dependabot configuration (will be deactivated by repository archival)

## Test plan

- [ ] README renders correctly with archive notice
- [ ] Version is 0.4.3 in both package.json and package-lock.json

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Deprecation**
  * Repository archived and npm package deprecated; README now directs users to use EJS directly via its API/CLI.

* **Documentation**
  * Added a prominent deprecation/caution notice at the top of the README.
  * Removed Code Climate badges (Test Coverage and Maintainability) from the README.

* **Chores**
  * Version bumped to 0.4.3.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->